### PR TITLE
function to extract .github worflows CI

### DIFF
--- a/find_store_github_actions.R
+++ b/find_store_github_actions.R
@@ -1,0 +1,19 @@
+find_store_github_actions <- function(repo,
+                                      github_pattern = "\\.github.*workflows.*(yml|yaml)",
+                                      github_folder_name = "github_actions") {
+
+  if (!dir.exists(github_folder_name)) {
+    invisible(dir.create(github_folder_name, showWarnings = FALSE))
+  }
+
+  files = list.files('tmp', recursive = TRUE, all.files = TRUE)
+
+  if (length(files_found <- grep(github_pattern, files, value = TRUE))) {
+    cat('\t Found .github \n')
+    invisible(dir.create(file.path(github_folder_name, basename(repo)), showWarnings = FALSE))
+    for (file in files_found) {
+      out_file = file.path(github_folder_name, basename(repo), basename(file))
+      file.rename(file.path('tmp', file[1L]), out_file)
+    }
+  }
+}

--- a/update.R
+++ b/update.R
@@ -1,3 +1,5 @@
+source("find_store_github_actions.R", encoding = "UTF-8")
+
 repos = readLines('.tracked_repos')
 
 # file patterns; e.g. appveyor can be .appveyor.yml or appveyor.yml
@@ -52,5 +54,7 @@ for (repo in repos) {
       file.rename(file.path('tmp', file[1L]), file.path(names(meta), out_file))
     }
   }
+  # find github actions workflows
+  find_store_github_actions(repo)
   unlink('tmp', recursive = TRUE, force = TRUE)
 }


### PR DESCRIPTION
Extension of the existing CI tools, to extract also GitHub Actions Workflows, if they are stored in the expected folder - .github/workflows/.

Unlike for other CI tools here, a folder is created for each repo as there may be more than one workflow defined.